### PR TITLE
Update the webaudio-benchmark repo, and add grafana dashboard

### DIFF
--- a/jenkins/run.sh
+++ b/jenkins/run.sh
@@ -14,6 +14,7 @@ VERSION=`python $JENKINS_DIR/firefox_version.py $FIREFOX_URL`
 if [ `uname` = 'Linux' ]; then
    python -m mozbench.mozbench --firefox-url $FIREFOX_URL/$VERSION.linux-x86_64.tar.bz2 --chrome-path google-chrome --log-mach=- --log-mach-level=info --post-results
 elif [ `uname` = 'Darwin' ]; then
+   rm -rf FirefoxNightly.app/
    python -m mozbench.mozbench --firefox-url $FIREFOX_URL/$VERSION.mac.dmg --chrome-path "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --log-mach=- --log-mach-level=info  --post-results
 fi
 

--- a/mozbench/static/webaudio-benchmark/README.md
+++ b/mozbench/static/webaudio-benchmark/README.md
@@ -1,0 +1,20 @@
+# webaudio-benchmark
+
+## Run
+
+Just open `index.html`. Time are in milliseconds, lower is better.
+
+## Adding new benchmarks
+
+Look into `benchmarks.js`, it's pretty straightforward.
+
+## Grafana dashboard
+
+When adding new benchmarks, run `node generate-grafana-dashboard.js`, this
+should overwrite `webaudio.json` so that the new benchmarks are registered in
+grafana.
+
+
+## License
+
+MPL 2.0

--- a/mozbench/static/webaudio-benchmark/generate-grafana-dashboard.js
+++ b/mozbench/static/webaudio-benchmark/generate-grafana-dashboard.js
@@ -1,0 +1,21 @@
+var OUTPUT_PATH="webaudio.json";
+
+var benchmarks = require("./benchmarks.js");
+var template = require("./template-row.json");
+var dashboard = require("./webaudio-dashboard.json");
+var fs = require('fs');
+
+var str = JSON.stringify(template);
+
+var names = benchmarks.benchmarks;
+for (var i in benchmarks.benchmarks) {
+  dashboard.rows.push(JSON.parse(str.replace(/{{}}/g, names[i])));
+}
+
+fs.writeFile(OUTPUT_PATH, JSON.stringify(dashboard, " ", 2), function(err) {
+  if(err) {
+    return console.log(err);
+  }
+
+  console.log("grafana dashboard saved as " + OUTPUT_PATH);
+});

--- a/mozbench/static/webaudio-benchmark/index.html
+++ b/mozbench/static/webaudio-benchmark/index.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <script src=webaudio-bench.js></script>
+<script src=benchmarks.js></script>
 <meta charset="utf-8">
 <style>
   html {
@@ -39,123 +40,5 @@
 </div>
 <div id=results>
 </div>
-<script>
-registerTestFile("think-mono-48000.wav");
-registerTestFile("think-mono-44100.wav");
-registerTestFile("think-mono-38000.wav");
-registerTestFile("think-stereo-48000.wav");
-registerTestFile("think-stereo-44100.wav");
-registerTestFile("think-stereo-38000.wav");
-
-
-registerTestCase(function () {
-  var oac = new OfflineAudioContext(1, 120 * samplerate, samplerate);
-  var source0 = oac.createBufferSource();
-  source0.buffer = getSpecificFile({rate: oac.samplerate, channels:1});
-  source0.loop = true;
-  source0.connect(oac.destination);
-  source0.start(0);
-  return {
-    context: oac,
-    name: "Simple gain test without resampling"
-  };
-});
-registerTestCase(function () {
-  var oac = new OfflineAudioContext(2, 120 * samplerate, samplerate);
-  var source0 = oac.createBufferSource();
-  source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
-  source0.loop = true;
-  source0.connect(oac.destination);
-  source0.start(0);
-  return {
-    context: oac,
-    name: "Simple gain test without resampling (Stereo)"
-  };
-});
-registerTestCase(function () {
-  var oac = new OfflineAudioContext(1, 120 * samplerate, samplerate);
-  var source0 = oac.createBufferSource();
-  source0.buffer = getSpecificFile({rate: 38000, channels:1});
-  source0.loop = true;
-  source0.connect(oac.destination);
-  source0.start(0);
-  return {
-    context: oac,
-    name: "Simple gain test"
-  };
-});
-registerTestCase(function () {
-  var oac = new OfflineAudioContext(2, 120 * samplerate, samplerate);
-  var source0 = oac.createBufferSource();
-  source0.buffer = getSpecificFile({rate: 38000, channels:2});
-  source0.loop = true;
-  source0.connect(oac.destination);
-  source0.start(0);
-  return {
-    context: oac,
-    name: "Simple gain test (Stereo)"
-  };
-});
-registerTestCase(function () {
-  var oac = new OfflineAudioContext(2, 120 * samplerate, samplerate);
-  var source0 = oac.createBufferSource();
-  source0.buffer = getSpecificFile({rate: oac.samplerate, channels:1});
-  source0.loop = true;
-  source0.connect(oac.destination);
-  source0.start(0);
-  return {
-    context: oac,
-    name: "Upmix without resampling (Mono -> Stereo)"
-  };
-});
-registerTestCase(function () {
-  var oac = new OfflineAudioContext(1, 120 * samplerate, samplerate);
-  var source0 = oac.createBufferSource();
-  source0.buffer = getSpecificFile({rate: oac.samplerate, channels:2});
-  source0.loop = true;
-  source0.connect(oac.destination);
-  source0.start(0);
-  return {
-    context: oac,
-    name: "Downmix without resampling (Mono -> Stereo)"
-  };
-});
-registerTestCase(function() {
-  var oac = new OfflineAudioContext(2, 30 * samplerate, samplerate);
-  for (var i = 0; i < 100; i++) {
-    var source0 = oac.createBufferSource();
-    source0.buffer = getSpecificFile({rate: 38000, channels:1});
-    source0.loop = true;
-    source0.connect(oac.destination);
-    source0.start(0);
-  }
-  return {
-    context: oac,
-    name: "Simple mixing (same buffer)"
-  };
-});
-registerTestCase(function() {
-  var oac = new OfflineAudioContext(2, 30 * samplerate, samplerate);
-  var reference = getSpecificFile({rate: 38000, channels:1}).getChannelData(0);
-  for (var i = 0; i < 100; i++) {
-    var source0 = oac.createBufferSource();
-    // copy the buffer into the a new one, so we know the implementation is not
-    // sharing them.
-    var b = oac.createBuffer(1, reference.length, 38000);
-    var data = b.getChannelData(0);
-    for (var j = 0; j < b.length; j++) {
-      data[i] = reference[i];
-    }
-    source0.buffer = b;
-    source0.loop = true;
-    source0.connect(oac.destination);
-    source0.start(0);
-  }
-  return {
-    context: oac,
-    name: "Simple mixing (different buffers)"
-  };
-});
-</script>
 </body>
 </html>

--- a/mozbench/static/webaudio-benchmark/template-row.json
+++ b/mozbench/static/webaudio-benchmark/template-row.json
@@ -1,0 +1,79 @@
+{
+  "title": "{{}}",
+  "height": "250px",
+  "editable": true,
+  "collapse": true,
+  "panels": [
+    {
+      "title": "{{}}",
+      "error": false,
+      "span": 12,
+      "editable": true,
+      "type": "graph",
+      "id": 1,
+      "datasource": null,
+      "renderer": "flot",
+      "x-axis": true,
+      "y-axis": true,
+      "y_formats": [
+        "short",
+        "short"
+      ],
+      "grid": {
+        "leftMax": null,
+        "rightMax": null,
+        "leftMin": null,
+        "rightMin": null,
+        "threshold1": null,
+        "threshold2": null,
+        "threshold1Color": "rgba(216, 200, 27, 0.27)",
+        "threshold2Color": "rgba(234, 112, 112, 0.22)"
+      },
+      "lines": true,
+      "fill": 0,
+      "linewidth": 1,
+      "points": true,
+      "pointradius": 5,
+      "bars": false,
+      "stack": false,
+      "percentage": false,
+      "legend": {
+        "show": true,
+        "values": false,
+        "min": false,
+        "max": false,
+        "current": false,
+        "total": false,
+        "avg": false,
+        "alignAsTable": false
+      },
+      "nullPointMode": "connected",
+      "steppedLine": false,
+      "tooltip": {
+        "value_type": "cumulative",
+        "shared": false
+      },
+      "targets": [
+        {
+          "function": "mean",
+          "column": "value",
+          "series": "benchmarks.webaudio-padenot.{{}}.linux.firefox.nightly",
+          "query": "select mean(value) from \"benchmarks.webaudio-padenot.{{}}.linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+          "hide": false
+        },
+        {
+          "function": "mean",
+          "column": "value",
+          "series": "benchmarks.webaudio-padenot.{{}}.linux.chrome.canary",
+          "query": "select mean(value) from \"benchmarks.webaudio-padenot.{{}}.linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+          "hide": false,
+          "groupby_field": ""
+        }
+      ],
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "links": [],
+      "leftYAxisLabel": "Time in milliseconds, lower is better"
+    }
+  ]
+}

--- a/mozbench/static/webaudio-benchmark/update.sh
+++ b/mozbench/static/webaudio-benchmark/update.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+usage() {
+  echo "Usage:"
+  echo "\t$0" /path/to/webaudio-benchmarks
+  exit 1
+}
+
+if [ $# != "1" ]
+then
+  usage $0
+fi
+
+cp $1/* .

--- a/mozbench/static/webaudio-benchmark/webaudio-bench.js
+++ b/mozbench/static/webaudio-benchmark/webaudio-bench.js
@@ -41,7 +41,7 @@ function recordResult(result) {
 }
 
 function benchmark(testcase, ended) {
-  var context = testcase.context;
+  var context = testcase.ctx;
   var start;
 
   context.oncomplete = function(e) {
@@ -89,6 +89,7 @@ function allDone() {
   var str = "<table><thead><tr><td>Test name</td><td>Time in ms</td><td>Speedup vs. realtime</td><td>Sound</td></tr></thead>";
   var buffers_base = buffers.length;
   var product_of_durations = 1.0;
+
   for (var i = 0 ; i < results.length; i++) {
     var r = results[i];
     product_of_durations *= r.duration;
@@ -132,10 +133,10 @@ function allDone() {
 
   document.getElementById("run-all").disabled = false;
 
-  var xmlHttp = new XMLHttpRequest();
-  xmlHttp.open("POST", "/results", true);
-  xmlHttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-  xmlHttp.send("results=" + JSON.stringify(results));
+  var xhr = new XMLHttpRequest();
+  xhr.open("POST", "/results", true);
+  xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+  xhr.send("results=" + JSON.stringify(results));
 }
 
 function runOne(i) {
@@ -157,7 +158,9 @@ function runAll() {
 
 function initAll() {
   for (var i = 0; i < testcases_registered.length; i++) {
-    testcases[i] = testcases_registered[i]();
+    testcases[i] = {};
+    testcases[i].ctx = testcases_registered[i].func();
+    testcases[i].name = testcases_registered[i].name;
   }
 }
 

--- a/mozbench/static/webaudio-benchmark/webaudio-dashboard.json
+++ b/mozbench/static/webaudio-benchmark/webaudio-dashboard.json
@@ -1,0 +1,57 @@
+{
+  "id": null,
+  "title": "Web Audio API benchmark",
+  "originalTitle": "Web Audio API benchmark",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [ ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "enable": true,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "now": true,
+      "notice": false
+    }
+  ],
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "version": 6,
+  "hideAllLegends": false
+}

--- a/mozbench/static/webaudio-benchmark/webaudio.json
+++ b/mozbench/static/webaudio-benchmark/webaudio.json
@@ -1,0 +1,848 @@
+{
+  "id": null,
+  "title": "Web Audio API benchmark",
+  "originalTitle": "Web Audio API benchmark",
+  "tags": [],
+  "style": "dark",
+  "timezone": "browser",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "rows": [
+    {
+      "title": "Simple gain test without resampling",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple gain test without resampling",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test without resampling.linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test without resampling.linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test without resampling.linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test without resampling.linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple gain test without resampling (Stereo)",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple gain test without resampling (Stereo)",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test without resampling (Stereo).linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test without resampling (Stereo).linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test without resampling (Stereo).linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test without resampling (Stereo).linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple gain test",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple gain test",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test.linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test.linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test.linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test.linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple gain test (Stereo)",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple gain test (Stereo)",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test (Stereo).linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test (Stereo).linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple gain test (Stereo).linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple gain test (Stereo).linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Upmix without resampling (Mono -> Stereo)",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Upmix without resampling (Mono -> Stereo)",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Upmix without resampling (Mono -> Stereo).linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Upmix without resampling (Mono -> Stereo).linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Upmix without resampling (Mono -> Stereo).linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Upmix without resampling (Mono -> Stereo).linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Downmix without resampling (Mono -> Stereo)",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Downmix without resampling (Mono -> Stereo)",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Downmix without resampling (Mono -> Stereo).linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Downmix without resampling (Mono -> Stereo).linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Downmix without resampling (Mono -> Stereo).linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Downmix without resampling (Mono -> Stereo).linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple mixing (same buffer)",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple mixing (same buffer)",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing (same buffer).linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing (same buffer).linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing (same buffer).linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing (same buffer).linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Simple mixing (different buffers)",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Simple mixing (different buffers)",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing (different buffers).linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing (different buffers).linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Simple mixing (different buffers).linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Simple mixing (different buffers).linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Convolution reverb",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Convolution reverb",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Convolution reverb.linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Convolution reverb.linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Convolution reverb.linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Convolution reverb.linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    },
+    {
+      "title": "Granular synthesis",
+      "height": "250px",
+      "editable": true,
+      "collapse": true,
+      "panels": [
+        {
+          "title": "Granular synthesis",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "graph",
+          "id": 1,
+          "datasource": null,
+          "renderer": "flot",
+          "x-axis": true,
+          "y-axis": true,
+          "y_formats": [
+            "short",
+            "short"
+          ],
+          "grid": {
+            "leftMax": null,
+            "rightMax": null,
+            "leftMin": null,
+            "rightMin": null,
+            "threshold1": null,
+            "threshold2": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": true,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "percentage": false,
+          "legend": {
+            "show": true,
+            "values": false,
+            "min": false,
+            "max": false,
+            "current": false,
+            "total": false,
+            "avg": false,
+            "alignAsTable": false
+          },
+          "nullPointMode": "connected",
+          "steppedLine": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "shared": false
+          },
+          "targets": [
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Granular synthesis.linux.firefox.nightly",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Granular synthesis.linux.firefox.nightly\" where $timeFilter group by time($interval) order asc",
+              "hide": false
+            },
+            {
+              "function": "mean",
+              "column": "value",
+              "series": "benchmarks.webaudio-padenot.Granular synthesis.linux.chrome.canary",
+              "query": "select mean(value) from \"benchmarks.webaudio-padenot.Granular synthesis.linux.chrome.canary\" where $timeFilter group by time($interval) order asc",
+              "hide": false,
+              "groupby_field": ""
+            }
+          ],
+          "aliasColors": {},
+          "seriesOverrides": [],
+          "links": [],
+          "leftYAxisLabel": "Time in milliseconds, lower is better"
+        }
+      ]
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "enable": true,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "now": true,
+      "notice": false
+    }
+  ],
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "templating": {
+    "list": []
+  },
+  "annotations": {
+    "list": []
+  },
+  "version": 6,
+  "hideAllLegends": false
+}


### PR DESCRIPTION
Dan, would it be possible to add  `mozbench/static/webaudio-benchmark/webaudio.json` to our grafana instance ? I verified it works, but I can't save the results, only import it temporarily.

This also add new benchmarks. 