### PR TITLE
Let object's destructor cleanups itself

### DIFF
--- a/mozbench/mozbench.py
+++ b/mozbench/mozbench.py
@@ -93,7 +93,6 @@ class B2GRunner(object):
         browser = m.find_element('css selector', 'iframe[src="app://search.gaiamobile.org/newtab.html"]')
         m.switch_to_frame(browser)
         m.execute_script(script % self.cmdargs[0])
-        m.delete_session()
 
     def stop(self):
         pass


### PR DESCRIPTION
Here's my reasons for this change:
1. Marionette may throw exception while executing delete_session method, and it
handles this inside its destructor. If we call delete_session ourself then we
have to take care of this exception.

2. It's more RAII.