### PR TITLE
Sleep after switching frame to prevent halting

### DIFF
--- a/mozbench/mozbench.py
+++ b/mozbench/mozbench.py
@@ -96,6 +96,7 @@ class B2GRunner(object):
         #    print(x.id, x.get_attribute('src'))
         browser = m.find_element('css selector', 'iframe[src="app://search.gaiamobile.org/newtab.html"]')
         m.switch_to_frame(browser)
+        time.sleep(1)
         m.execute_script(script % self.cmdargs[0])
 
     def stop(self):


### PR DESCRIPTION
On b2g, it halts after switching frame to browser very often. I think switch_to_frame() do return after the frame changed (after the switching animation), but it's still too tight for execute_script() to complete its mission.